### PR TITLE
feature/code_quality (#76)

### DIFF
--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -44,17 +44,17 @@ logically ordered and cover both architectural and code-level improvements.
 
 ### Error Handling
 
-- [ ] Implement comprehensive error handling strategy
-- [ ] Add retry mechanisms for failed event processing
-- [ ] Create error reporting and notification system
-- [ ] Improve error logging with more context
+- [x] Implement comprehensive error handling strategy
+- [x] Add retry mechanisms for failed event processing
+- [x] Create error reporting and notification system
+- [x] Improve error logging with more context
 
 ### Code Quality
 
-- [ ] Fix SuppressWarnings usage (replace with proper type safety)
-- [ ] Address TODO comments in the codebase
-- [ ] Implement consistent naming conventions
-- [ ] Reduce code duplication in event handling logic
+- [x] Fix SuppressWarnings usage (replace with proper type safety)
+- [x] Address TODO comments in the codebase
+- [x] Implement consistent naming conventions
+- [x] Reduce code duplication in event handling logic
 
 ### API Improvements
 
@@ -81,10 +81,10 @@ logically ordered and cover both architectural and code-level improvements.
 
 ### Code Cleanup
 
-- [ ] Remove experimental annotations where implementation is stable
-- [ ] Fix raw type usage in generics
-- [ ] Address compiler warnings
-- [ ] Remove unused code and dead code paths
+- [x] Remove experimental annotations where implementation is stable
+- [x] Fix raw type usage in generics
+- [x] Address compiler warnings
+- [x] Remove unused code and dead code paths
 
 ### Refactoring
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,8 @@
   ~ SPDX-License-Identifier: AGPL-3.0-only
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.fluxtion</groupId>

--- a/src/main/java/com/fluxtion/server/FluxtionServer.java
+++ b/src/main/java/com/fluxtion/server/FluxtionServer.java
@@ -12,7 +12,6 @@ import com.fluxtion.agrona.concurrent.IdleStrategy;
 import com.fluxtion.agrona.concurrent.UnsafeBuffer;
 import com.fluxtion.agrona.concurrent.status.AtomicCounter;
 import com.fluxtion.runtime.StaticEventProcessor;
-import com.fluxtion.runtime.annotations.feature.Experimental;
 import com.fluxtion.runtime.annotations.runtime.ServiceRegistered;
 import com.fluxtion.runtime.audit.EventLogControlEvent;
 import com.fluxtion.runtime.audit.LogRecordListener;
@@ -37,7 +36,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-@Experimental
 @Log
 public class FluxtionServer implements FluxtionServerController {
 

--- a/src/main/java/com/fluxtion/server/config/ConfigMap.java
+++ b/src/main/java/com/fluxtion/server/config/ConfigMap.java
@@ -19,11 +19,13 @@ public class ConfigMap {
     }
 
     // Legacy string-based accessors (kept for backward compatibility)
+    @Deprecated
     @SuppressWarnings({"unchecked"})
     public <T> T get(String key) {
         return (T) configMap.get(key);
     }
 
+    @Deprecated
     @SuppressWarnings({"unchecked"})
     public <T> T getOrDefault(String key, T defaultValue) {
         return (T) configMap.getOrDefault(key, defaultValue);

--- a/src/main/java/com/fluxtion/server/config/EventFeedConfig.java
+++ b/src/main/java/com/fluxtion/server/config/EventFeedConfig.java
@@ -42,8 +42,7 @@ public class EventFeedConfig<T> {
     }
 
     @SneakyThrows
-    @SuppressWarnings({"unchecked", "all"})
-    public Service<T> toService() {
+    public Service<NamedFeed> toService() {
         if (instance instanceof EventSource<?> eventSource) {
             if (wrapWithNamedEvent & broadcast) {
                 eventWrapStrategy = EventSource.EventWrapStrategy.BROADCAST_NAMED_EVENT;
@@ -54,19 +53,21 @@ public class EventFeedConfig<T> {
             } else {
                 eventWrapStrategy = EventSource.EventWrapStrategy.SUBSCRIPTION_NOWRAP;
             }
-            EventSource<T> eventSource_t = (EventSource<T>) eventSource;
+            @SuppressWarnings("unchecked") EventSource<T> eventSource_t = (EventSource<T>) eventSource;
             eventSource_t.setEventWrapStrategy(eventWrapStrategy);
             eventSource_t.setSlowConsumerStrategy(slowConsumerStrategy);
             eventSource_t.setDataMapper(valueMapper);
         }
-        Service svc = new Service(instance, NamedFeed.class, name);
+        Service<NamedFeed> svc = new Service<>((NamedFeed) instance, NamedFeed.class, name);
         return svc;
     }
 
     @SneakyThrows
-    @SuppressWarnings({"unchecked", "all"})
-    public <A extends Agent> ServiceAgent<A> toServiceAgent() {
-        Service svc = toService();
-        return new ServiceAgent<>(agentName, idleStrategy, svc, (A) instance);
+    public ServiceAgent<NamedFeed> toServiceAgent() {
+        Service<NamedFeed> svc = toService();
+        if (!(instance instanceof Agent a)) {
+            throw new IllegalArgumentException("Configured instance is not an Agent: " + instance);
+        }
+        return new ServiceAgent<>(agentName, idleStrategy, svc, a);
     }
 }

--- a/src/main/java/com/fluxtion/server/config/EventProcessorConfig.java
+++ b/src/main/java/com/fluxtion/server/config/EventProcessorConfig.java
@@ -25,7 +25,7 @@ public class EventProcessorConfig<T extends EventProcessor<?>> {
     private ObjectEventHandlerNode customHandler;
     private Supplier<T> eventHandlerBuilder;
     private EventLogControlEvent.LogLevel logLevel;
-    @Getter(AccessLevel.NONE)
+    @Getter(AccessLevel.PRIVATE)
     @Setter(AccessLevel.NONE)
     private Map<String, Object> configMap = new HashMap<>();
 
@@ -36,16 +36,6 @@ public class EventProcessorConfig<T extends EventProcessor<?>> {
             eventHandler = (T) wrappingProcessor;
         }
         return eventHandler;
-    }
-
-    @SuppressWarnings({"raw"})
-    public Map<String, Object> getConfigMap() {
-        return configMap;
-    }
-
-    @SuppressWarnings({"raw"})
-    public void setConfigMap(Map<String, Object> configMap) {
-        this.configMap = configMap;
     }
 
     public ConfigMap getConfig() {

--- a/src/main/java/com/fluxtion/server/config/ServiceConfig.java
+++ b/src/main/java/com/fluxtion/server/config/ServiceConfig.java
@@ -7,7 +7,6 @@ package com.fluxtion.server.config;
 
 import com.fluxtion.agrona.concurrent.Agent;
 import com.fluxtion.agrona.concurrent.IdleStrategy;
-import com.fluxtion.runtime.annotations.feature.Experimental;
 import com.fluxtion.runtime.service.Service;
 import com.fluxtion.server.dutycycle.ServiceAgent;
 import lombok.AllArgsConstructor;
@@ -16,7 +15,6 @@ import lombok.NoArgsConstructor;
 import lombok.SneakyThrows;
 import lombok.experimental.Accessors;
 
-@Experimental
 @Data
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/fluxtion/server/dispatch/EventFlowManager.java
+++ b/src/main/java/com/fluxtion/server/dispatch/EventFlowManager.java
@@ -9,7 +9,6 @@ import com.fluxtion.agrona.concurrent.Agent;
 import com.fluxtion.agrona.concurrent.ManyToOneConcurrentArrayQueue;
 import com.fluxtion.agrona.concurrent.OneToOneConcurrentArrayQueue;
 import com.fluxtion.runtime.StaticEventProcessor;
-import com.fluxtion.runtime.annotations.feature.Experimental;
 import com.fluxtion.server.dutycycle.EventQueueToEventProcessor;
 import com.fluxtion.server.dutycycle.EventQueueToEventProcessorAgent;
 import lombok.Value;
@@ -29,13 +28,12 @@ import java.util.function.Supplier;
  *     <li>{@link EventToInvokeStrategy} - processed an event and map events to callbacks on the {@link com.fluxtion.runtime.StaticEventProcessor}</li>
  * </ul>
  */
-@Experimental
 public class EventFlowManager {
 
     private final ConcurrentHashMap<com.fluxtion.server.dispatch.EventSourceKey<?>, EventSource_QueuePublisher<?>> eventSourceToQueueMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<EventSinkKey<?>, ManyToOneConcurrentArrayQueue<?>> eventSinkToQueueMap = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<com.fluxtion.server.dispatch.CallBackType, Supplier<EventToInvokeStrategy>> eventToInvokerFactoryMap = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<EventSourceKey_Subscriber<?>, OneToOneConcurrentArrayQueue<?>> subscriberKeyToQueueMap = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<EventSourceKey_Subscriber<?>, OneToOneConcurrentArrayQueue<Object>> subscriberKeyToQueueMap = new ConcurrentHashMap<>();
     private final static ThreadLocal<AtomicReference<StaticEventProcessor>> currentProcessor = new ThreadLocal<>();
 
     public static void setCurrentProcessor(StaticEventProcessor eventProcessor) {
@@ -152,7 +150,7 @@ public class EventFlowManager {
 
         //create or re-use a target queue
         EventSourceKey_Subscriber<T> keySubscriber = new EventSourceKey_Subscriber<>(eventSourceKey, subscriber);
-        OneToOneConcurrentArrayQueue eventQueue = subscriberKeyToQueueMap.computeIfAbsent(
+        OneToOneConcurrentArrayQueue<Object> eventQueue = subscriberKeyToQueueMap.computeIfAbsent(
                 keySubscriber,
                 key -> new OneToOneConcurrentArrayQueue<>(1024));
 
@@ -160,7 +158,14 @@ public class EventFlowManager {
         String name = subscriber.roleName() + "/" + eventSourceKey.getSourceName() + "/" + type.name();
         eventSourceQueuePublisher.getQueuePublisher().addTargetQueue(eventQueue, name);
 
-        return new EventQueueToEventProcessorAgent(eventQueue, eventMapperSupplier.get(), name);
+        Runnable unsubscribe = () -> {
+            // remove target queue and cached mapping for this subscriber
+            eventSourceQueuePublisher.getQueuePublisher().removeTargetQueueByName(name);
+            subscriberKeyToQueueMap.remove(keySubscriber);
+        };
+
+        return new EventQueueToEventProcessorAgent(eventQueue, eventMapperSupplier.get(), name)
+                .withUnsubscribeAction(unsubscribe);
     }
 
     public <T> EventQueueToEventProcessor getMappingAgent(EventSubscriptionKey<T> subscriptionKey, Agent subscriber) {

--- a/src/main/java/com/fluxtion/server/dispatch/EventSourceKey.java
+++ b/src/main/java/com/fluxtion/server/dispatch/EventSourceKey.java
@@ -6,10 +6,8 @@
 
 package com.fluxtion.server.dispatch;
 
-import com.fluxtion.runtime.annotations.feature.Experimental;
 import lombok.Value;
 
-@Experimental
 @Value
 public class EventSourceKey<T> {
     String sourceName;

--- a/src/main/java/com/fluxtion/server/dispatch/EventSubscriptionKey.java
+++ b/src/main/java/com/fluxtion/server/dispatch/EventSubscriptionKey.java
@@ -6,10 +6,8 @@
 
 package com.fluxtion.server.dispatch;
 
-import com.fluxtion.runtime.annotations.feature.Experimental;
 import lombok.Value;
 
-@Experimental
 @Value
 public class EventSubscriptionKey<T> {
     com.fluxtion.server.dispatch.EventSourceKey<T> eventSourceKey;

--- a/src/main/java/com/fluxtion/server/dispatch/RetryPolicy.java
+++ b/src/main/java/com/fluxtion/server/dispatch/RetryPolicy.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.dispatch;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Simple retry policy for event processing.
+ */
+public final class RetryPolicy {
+    private final int maxAttempts;
+    private final long initialBackoffMillis;
+    private final long maxBackoffMillis;
+    private final double multiplier;
+    private final Set<Class<? extends Throwable>> retryOn;
+
+    public RetryPolicy(int maxAttempts, long initialBackoffMillis, long maxBackoffMillis, double multiplier,
+                       Set<Class<? extends Throwable>> retryOn) {
+        if (maxAttempts < 1) throw new IllegalArgumentException("maxAttempts must be >=1");
+        if (initialBackoffMillis < 0 || maxBackoffMillis < 0) throw new IllegalArgumentException("backoff must be >=0");
+        if (multiplier < 1.0) throw new IllegalArgumentException("multiplier must be >=1.0");
+        this.maxAttempts = maxAttempts;
+        this.initialBackoffMillis = initialBackoffMillis;
+        this.maxBackoffMillis = Math.max(maxBackoffMillis, initialBackoffMillis);
+        this.multiplier = multiplier;
+        this.retryOn = retryOn;
+    }
+
+    public static RetryPolicy defaultProcessingPolicy() {
+        // Default to 3 attempts, starting at 5ms, up to 100ms, x2 multiplier, retry on all RuntimeExceptions
+        return new RetryPolicy(3, 5, 100, 2.0, Set.of(RuntimeException.class));
+    }
+
+    public boolean shouldRetry(Throwable t, int attempt) {
+        if (attempt >= maxAttempts) {
+            return false;
+        }
+        if (retryOn == null || retryOn.isEmpty()) {
+            return true;
+        }
+        for (Class<? extends Throwable> c : retryOn) {
+            if (c.isInstance(t)) return true;
+        }
+        return false;
+    }
+
+    public void backoff(int attempt) {
+        if (initialBackoffMillis <= 0) return;
+        long delay = (long) Math.min(maxBackoffMillis, initialBackoffMillis * Math.pow(multiplier, Math.max(0, attempt - 1)));
+        try {
+            TimeUnit.MILLISECONDS.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    public int getMaxAttempts() {
+        return maxAttempts;
+    }
+
+    public long getInitialBackoffMillis() {
+        return initialBackoffMillis;
+    }
+
+    public long getMaxBackoffMillis() {
+        return maxBackoffMillis;
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+}

--- a/src/main/java/com/fluxtion/server/service/admin/impl/AdminCommandProcessor.java
+++ b/src/main/java/com/fluxtion/server/service/admin/impl/AdminCommandProcessor.java
@@ -31,7 +31,7 @@ public class AdminCommandProcessor implements EventFlowService, AdminCommandRegi
     private final Map<String, AdminCommand> registeredCommandMap = new HashMap<>();
     private EventFlowManager eventFlowManager;
 
-    private static final String help = """
+    private static final String HELP_MESSAGE = """
             default commands:
             ---------------------------
             quit         - exit the console
@@ -102,7 +102,7 @@ public class AdminCommandProcessor implements EventFlowService, AdminCommandRegi
     }
 
     private void printHelp(List<String> args, Consumer<String> out, Consumer<String> err) {
-        out.accept(help);
+        out.accept(HELP_MESSAGE);
     }
 
     private void printQueues(List<String> args, Consumer<String> out, Consumer<String> err) {

--- a/src/main/java/com/fluxtion/server/service/error/DefaultErrorReporter.java
+++ b/src/main/java/com/fluxtion/server/service/error/DefaultErrorReporter.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+import lombok.extern.java.Log;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Level;
+
+/** Default in-memory error reporter that logs and notifies listeners. */
+@Log
+public class DefaultErrorReporter implements ErrorReporter {
+    private final CopyOnWriteArrayList<ErrorListener> listeners = new CopyOnWriteArrayList<>();
+    private final ArrayDeque<ErrorEvent> ring = new ArrayDeque<>(128);
+    private final int capacity;
+
+    public DefaultErrorReporter() { this(100); }
+    public DefaultErrorReporter(int capacity) { this.capacity = Math.max(1, capacity); }
+
+    @Override
+    public void addListener(ErrorListener listener) {
+        if (listener != null) listeners.addIfAbsent(listener);
+    }
+
+    @Override
+    public void removeListener(ErrorListener listener) {
+        if (listener != null) listeners.remove(listener);
+    }
+
+    @Override
+    public void report(ErrorEvent event) {
+        if (event == null) return;
+        // keep a bounded history
+        synchronized (ring) {
+            if (ring.size() >= capacity) {
+                ring.removeFirst();
+            }
+            ring.addLast(event);
+        }
+        // log
+        Level level = switch (event.getSeverity()) {
+            case INFO -> Level.INFO;
+            case WARNING -> Level.WARNING;
+            case ERROR, CRITICAL -> Level.SEVERE;
+        };
+        if (event.getError() != null) {
+            log.log(level, event.getSource() + ": " + event.getMessage(), event.getError());
+        } else {
+            log.log(level, event.getSource() + ": " + event.getMessage());
+        }
+        // notify
+        for (ErrorListener l : listeners) {
+            try {
+                l.onError(event);
+            } catch (Throwable t) {
+                log.log(Level.WARNING, "error listener threw exception: " + l + ", error=" + t, t);
+            }
+        }
+    }
+
+    @Override
+    public List<ErrorEvent> recent(int limit) {
+        List<ErrorEvent> list = new ArrayList<>();
+        if (limit <= 0) return list;
+        synchronized (ring) {
+            int size = ring.size();
+            int start = Math.max(0, size - limit);
+            int i = 0;
+            for (ErrorEvent e : ring) {
+                if (i++ >= start) list.add(e);
+            }
+        }
+        return list;
+    }
+}

--- a/src/main/java/com/fluxtion/server/service/error/ErrorEvent.java
+++ b/src/main/java/com/fluxtion/server/service/error/ErrorEvent.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Represents an error/alert that can be reported and broadcast to listeners.
+ */
+public final class ErrorEvent {
+    public enum Severity { INFO, WARNING, ERROR, CRITICAL }
+
+    private final Instant timestamp;
+    private final String source;
+    private final String message;
+    private final Throwable error;
+    private final Severity severity;
+
+    public ErrorEvent(String source, String message, Throwable error, Severity severity) {
+        this.timestamp = Instant.now();
+        this.source = source == null ? "unknown" : source;
+        this.message = message == null ? "" : message;
+        this.error = error;
+        this.severity = severity == null ? Severity.ERROR : severity;
+    }
+
+    public Instant getTimestamp() { return timestamp; }
+    public String getSource() { return source; }
+    public String getMessage() { return message; }
+    public Throwable getError() { return error; }
+    public Severity getSeverity() { return severity; }
+
+    @Override
+    public String toString() {
+        return "ErrorEvent{" +
+                "timestamp=" + timestamp +
+                ", source='" + source + '\'' +
+                ", message='" + message + '\'' +
+                ", severity=" + severity +
+                (error != null ? ", error=" + error : "") +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ErrorEvent that)) return false;
+        return Objects.equals(timestamp, that.timestamp) &&
+                Objects.equals(source, that.source) &&
+                Objects.equals(message, that.message) &&
+                severity == that.severity &&
+                Objects.equals(error == null ? null : error.toString(), that.error == null ? null : that.error.toString());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(timestamp, source, message, severity);
+    }
+}

--- a/src/main/java/com/fluxtion/server/service/error/ErrorListener.java
+++ b/src/main/java/com/fluxtion/server/service/error/ErrorListener.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+/** Listener of error events. */
+@FunctionalInterface
+public interface ErrorListener {
+    void onError(ErrorEvent event);
+}

--- a/src/main/java/com/fluxtion/server/service/error/ErrorReporter.java
+++ b/src/main/java/com/fluxtion/server/service/error/ErrorReporter.java
@@ -1,0 +1,17 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+import java.util.List;
+
+public interface ErrorReporter {
+    void addListener(ErrorListener listener);
+    void removeListener(ErrorListener listener);
+    void report(ErrorEvent event);
+    default void report(String source, String message, Throwable error, ErrorEvent.Severity severity) {
+        report(new ErrorEvent(source, message, error, severity));
+    }
+    List<ErrorEvent> recent(int limit);
+}

--- a/src/main/java/com/fluxtion/server/service/error/ErrorReporting.java
+++ b/src/main/java/com/fluxtion/server/service/error/ErrorReporting.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+/**
+ * Static facade for global error reporting. Allows core components to
+ * raise error notifications without wiring a reporter through constructors.
+ */
+public final class ErrorReporting {
+    private static volatile ErrorReporter reporter = new DefaultErrorReporter();
+
+    private ErrorReporting() {}
+
+    public static ErrorReporter getReporter() { return reporter; }
+
+    public static void setReporter(ErrorReporter customReporter) {
+        if (customReporter != null) reporter = customReporter;
+    }
+
+    public static void report(String source, String message, Throwable error, ErrorEvent.Severity severity) {
+        reporter.report(source, message, error, severity);
+    }
+}

--- a/src/test/java/com/fluxtion/server/benchmark/EventProcessingBenchmark.java
+++ b/src/test/java/com/fluxtion/server/benchmark/EventProcessingBenchmark.java
@@ -100,7 +100,6 @@ public class EventProcessingBenchmark {
 
         // Benchmark
         System.out.println("Running benchmark with " + BENCHMARK_COUNT + " events");
-        long now = System.nanoTime();
 
         for (int i = 0; i < BENCHMARK_COUNT; i++) {
             TestEvent event = eventCache[i];
@@ -109,7 +108,6 @@ public class EventProcessingBenchmark {
         }
 
         eventSource.publishEvent("publishResults");
-        long endTime = System.nanoTime();
         eventProcessedLatch.await();
 
         // Verify that the benchmark completed successfully
@@ -258,7 +256,6 @@ public class EventProcessingBenchmark {
         public void onEvent(Object event) {
             if (event instanceof TestEvent) {
                 handleTestEvent((TestEvent) event);
-                long start = System.nanoTime();
             } else if (event instanceof String) {
                 switch ((String) event) {
                     case "reset" -> handleReset((String) event);

--- a/src/test/java/com/fluxtion/server/dutycycle/EventQueueToEventProcessorAgentRetryTest.java
+++ b/src/test/java/com/fluxtion/server/dutycycle/EventQueueToEventProcessorAgentRetryTest.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.dutycycle;
+
+import com.fluxtion.agrona.concurrent.OneToOneConcurrentArrayQueue;
+import com.fluxtion.runtime.StaticEventProcessor;
+import com.fluxtion.server.dispatch.EventToInvokeStrategy;
+import com.fluxtion.server.dispatch.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class EventQueueToEventProcessorAgentRetryTest {
+
+    @Test
+    void retriesOnFailureAndEventuallySucceeds() {
+        TestQueue<Object> q = new TestQueue<>();
+        FailingThenSucceedStrategy strategy = new FailingThenSucceedStrategy(2); // fail twice then succeed
+        EventQueueToEventProcessorAgent agent = new EventQueueToEventProcessorAgent(q, strategy, "retryAgent")
+                .withRetryPolicy(new RetryPolicy(5, 0, 0, 1.0, java.util.Set.of(RuntimeException.class)));
+        agent.registerProcessor(new NoopProcessor());
+
+        String event = "E1";
+        q.offer(event);
+
+        int processed = agent.doWork();
+        assertEquals(1, processed, "one event should be processed in batch");
+        assertEquals(3, strategy.attempts, "should attempt 3 times (2 failures + 1 success)");
+        assertEquals(event, strategy.lastEvent, "event should be processed eventually");
+    }
+
+    @Test
+    void dropsAfterMaxRetries() {
+        TestQueue<Object> q = new TestQueue<>();
+        FailingThenSucceedStrategy strategy = new FailingThenSucceedStrategy(Integer.MAX_VALUE); // always fail
+        EventQueueToEventProcessorAgent agent = new EventQueueToEventProcessorAgent(q, strategy, "retryAgent")
+                .withRetryPolicy(new RetryPolicy(3, 0, 0, 1.0, java.util.Set.of(RuntimeException.class)));
+        agent.registerProcessor(new NoopProcessor());
+
+        String event = "E2";
+        q.offer(event);
+
+        int processed = agent.doWork();
+        assertEquals(1, processed, "agent should advance even when dropping event");
+        assertNull(strategy.lastEvent, "event should not be recorded as processed");
+        assertEquals(3, strategy.attempts, "should attempt exactly max attempts");
+    }
+
+    private static class TestQueue<T> extends OneToOneConcurrentArrayQueue<T> {
+        private final List<T> items = new ArrayList<>();
+        public TestQueue() { super(16); }
+        @Override public boolean offer(T item) { items.add(item); return true; }
+        @Override public T poll() { return items.isEmpty() ? null : items.remove(0); }
+    }
+
+    private static class NoopProcessor implements StaticEventProcessor {
+        @Override public void onEvent(Object event) { /* no-op */ }
+    }
+
+    private static class FailingThenSucceedStrategy implements EventToInvokeStrategy {
+        private final int failuresBeforeSuccess;
+        private int failures;
+        private final List<StaticEventProcessor> procs = new ArrayList<>();
+        int attempts;
+        Object lastEvent;
+        FailingThenSucceedStrategy(int failuresBeforeSuccess) { this.failuresBeforeSuccess = failuresBeforeSuccess; }
+        @Override public void processEvent(Object event) {
+            attempts++;
+            if (failures < failuresBeforeSuccess) {
+                failures++;
+                throw new RuntimeException("boom" + failures);
+            }
+            lastEvent = event;
+            for (StaticEventProcessor p : procs) p.onEvent(event);
+        }
+        @Override public void processEvent(Object event, long time) { processEvent(event); }
+        @Override public void registerProcessor(StaticEventProcessor eventProcessor) { procs.add(eventProcessor); }
+        @Override public void deregisterProcessor(StaticEventProcessor eventProcessor) { procs.remove(eventProcessor); }
+        @Override public int listenerCount() { return procs.size(); }
+    }
+}

--- a/src/test/java/com/fluxtion/server/integration/EndToEndEventFlowIT.java
+++ b/src/test/java/com/fluxtion/server/integration/EndToEndEventFlowIT.java
@@ -113,8 +113,6 @@ public class EndToEndEventFlowIT {
      * A test event source that can publish events.
      */
     private static class TestEventSource extends AbstractEventSourceService<TestEvent> {
-        private EventToQueuePublisher<TestEvent> publisher;
-
         public TestEventSource(String name) {
             super(name);
         }

--- a/src/test/java/com/fluxtion/server/service/error/ErrorReportingTest.java
+++ b/src/test/java/com/fluxtion/server/service/error/ErrorReportingTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: © 2025 Gregory Higgins <greg.higgins@v12technology.com>
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+package com.fluxtion.server.service.error;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ErrorReportingTest {
+
+    @AfterEach
+    void reset() {
+        // reset to default to avoid test side effects
+        ErrorReporting.setReporter(new DefaultErrorReporter());
+    }
+
+    @Test
+    void listenerReceivesReportedError() {
+        DefaultErrorReporter reporter = new DefaultErrorReporter(10);
+        ErrorReporting.setReporter(reporter);
+
+        List<ErrorEvent> received = new ArrayList<>();
+        reporter.addListener(received::add);
+
+        ErrorReporting.report("unit-test", "something went wrong", new RuntimeException("boom"), ErrorEvent.Severity.ERROR);
+
+        assertEquals(1, received.size());
+        ErrorEvent e = received.get(0);
+        assertEquals("unit-test", e.getSource());
+        assertEquals("something went wrong", e.getMessage());
+        assertEquals(ErrorEvent.Severity.ERROR, e.getSeverity());
+        assertNotNull(e.getError());
+    }
+
+    @Test
+    void recentReturnsHistoryBounded() {
+        DefaultErrorReporter reporter = new DefaultErrorReporter(3);
+        ErrorReporting.setReporter(reporter);
+        reporter.report(new ErrorEvent("s1", "m1", null, ErrorEvent.Severity.INFO));
+        reporter.report(new ErrorEvent("s2", "m2", null, ErrorEvent.Severity.WARNING));
+        reporter.report(new ErrorEvent("s3", "m3", null, ErrorEvent.Severity.ERROR));
+        reporter.report(new ErrorEvent("s4", "m4", null, ErrorEvent.Severity.CRITICAL));
+
+        List<ErrorEvent> last2 = reporter.recent(2);
+        assertEquals(2, last2.size());
+        assertEquals("s3", last2.get(0).getSource());
+        assertEquals("s4", last2.get(1).getSource());
+    }
+}


### PR DESCRIPTION
* refactor

* fixing admin broadcast when two admin executors are registered with the same key

* updating test

* feat(config): Add thread idle strategy lookup in AppConfig

Add utility methods to lookup and manage idle strategies for agent threads:
- lookupIdleStrategyWhenNull - provides fallback behavior for null idle strategies
- getIdleStrategyOrDefault - retrieves configured idle strategy with default fallback

* more fixes

* Bump com.fluxtion:runtime from 9.7.12 to 9.7.14 (#67)

Bumps [com.fluxtion:runtime](https://github.com/v12technology/fluxtion) from 9.7.12 to 9.7.14.
- [Release notes](https://github.com/v12technology/fluxtion/releases)
- [Commits](https://github.com/v12technology/fluxtion/compare/9.7.12...9.7.14)

---
updated-dependencies:
- dependency-name: com.fluxtion:runtime dependency-version: 9.7.14 dependency-type: direct:production update-type: version-update:semver-patch ...




* Bump org.junit.jupiter:junit-jupiter from 5.13.2 to 5.13.4 (#68)

Bumps [org.junit.jupiter:junit-jupiter](https://github.com/junit-team/junit-framework) from 5.13.2 to 5.13.4.
- [Release notes](https://github.com/junit-team/junit-framework/releases)
- [Commits](https://github.com/junit-team/junit-framework/compare/r5.13.2...r5.13.4)

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter dependency-version: 5.13.4 dependency-type: direct:development update-type: version-update:semver-patch ...




* Bump org.apache.maven.plugins:maven-gpg-plugin from 3.2.7 to 3.2.8 (#66)

Bumps [org.apache.maven.plugins:maven-gpg-plugin](https://github.com/apache/maven-gpg-plugin) from 3.2.7 to 3.2.8.
- [Release notes](https://github.com/apache/maven-gpg-plugin/releases)
- [Commits](https://github.com/apache/maven-gpg-plugin/compare/maven-gpg-plugin-3.2.7...maven-gpg-plugin-3.2.8)

---
updated-dependencies:
- dependency-name: org.apache.maven.plugins:maven-gpg-plugin dependency-version: 3.2.8 dependency-type: direct:production update-type: version-update:semver-patch ...




* Feature/ignore subscription qualifier (#69)

* remove qualifier from EventSubscriptionKey

* composing event handler test

* remove qualifier from EventSubscriptionKey and add tests

---------



* adding admin tests

* adding admin tests

* disabled unused test

* performance improvement on logging

* Added detailed architecture documentation.

* Refined architecture documentation formatting.

* Added sequence diagrams for event processing and subscription flows in Fluxtion Server architecture documentation. Updated task list to reflect progress.

* Added coding standards and best practices document, updated task list to reflect completion.

* feature/improve_testing (#73)

* refactor

* Added coding standards and best practices document, updated task list to reflect completion.

* Add tests for `AbstractEventSourceService` and `EventQueueToEventProcessorAgent`, enhance handling of event wrap strategy and data mapper.

* Refactor: Simplify test subscription handling, remove unused `TestEventSubscription` class, improve server stop logic, add E2E event flow integration test, and update JDK compatibility to 21.

* feat(config): add event handler configuration methods

- Add method to handle default event processor group config
- Implement event handler list initialization with default config
- Override getEventHandlers to support default configuration injection

* Update tasks document: mark performance benchmarks as complete

* feat(tests): add high-volume event stress tests and update task list

- Implement comprehensive stress tests to evaluate server behavior under extreme load, burst patterns, and increasing event rates.
- Update `tasks.md` to mark stress tests as complete.

* feat(benchmark): Improve event processing benchmarks and add detailed latency reporting

- Increased warmup and benchmark event counts for more robust results.
- Introduced caching for benchmark events to enhance test efficiency.
- Added detailed latency measurements, including full latency and average latency.
- Updated TestEvent class with new fields for publish and processed times.
- Enhanced TestEventProcessor to handle additional commands and calculate detailed metrics.

* feat(config): Introduce type-safe ConfigKey for configuration access

- Added `ConfigKey` class to enable strongly-typed, type-safe access to configuration values.
- Updated `ConfigMap` with new methods to support `ConfigKey` for retrieving, defaulting, and requiring configurations.
- Marked existing string-based accessors as legacy for backward compatibility.
- Updated tasks documentation: marked type-safe configuration refactor as complete.

* feat(benchmark): Enhance event processing benchmarks with improved handling and metrics

- Increased benchmark event count to 20M for higher throughput evaluation.
- Replaced `Thread.sleep` with `CountDownLatch` for accurate synchronization.
- Improved latency tracking in `TestEventProcessor` with better metrics calculation.
- Enhanced output with detailed latency and throughput statistics.
- Added new fields and logic in `TestEventProcessor` for event handling and reporting.

* feat(performance): Optimize event queue processing and memory usage

- Implemented batched event processing (up to 64 events) to reduce overhead per event in `EventQueueToEventProcessorAgent`.
- Updated capacity of concurrent queues from 500 to 1024 to improve scalability in high-volume scenarios.
- Adjusted logging conditionals and message formatting for consistency.
- Enhanced event publishing with recyclable wrappers to reduce memory pressure.
- Marked related scalability task as complete in documentation.

* downgrade compiler source and target version to 17 in pom.xml

* refactor EventProcessingBenchmark to use indexed access for first and last events

---------




* Feature/error handling (#75)

* Add retry handling with configurable policy for event processing

- Introduced `RetryPolicy` to manage retry attempts, backoff, and exception handling during event processing.
- Updated `EventQueueToEventProcessorAgent` to support retries with the new `RetryPolicy`.
- Added unit tests to verify retry mechanisms and max retry behavior.
- Enhanced `EventToQueuePublisher` with better error logging and handling for data mapping and queue operations.

* Implement in-memory error reporting system

- Added `DefaultErrorReporter` with bounded error history and listener notification.
- Introduced `ErrorEvent` and `ErrorListener` for representing and handling error events.
- Included `ErrorReporting` as a static facade for global error reporting.
- Enhanced `EventQueueToEventProcessorAgent` and `EventToQueuePublisher` with error reporting for critical failure scenarios.
- Updated `tasks.md` to reflect completion of error handling features.

---------



* Refactor to improve type safety, remove unnecessary warnings, and introduce unsubscribe logic for EventQueueToEventProcessorAgent.

* Refactor admin command constants and finalize naming convention implementation for consistency.

* Remove `@Experimental` annotations from core server classes.

* Remove `@Experimental` annotations and improve generics usage in server classes.

* Remove unused code and dead code paths across tests and benchmarks.

---------